### PR TITLE
adapt functions in simulations for adaptivve timestep

### DIFF
--- a/component.py
+++ b/component.py
@@ -6,7 +6,7 @@ class Component:
     Represents a component in a fuel cycle system.
     """
 
-    def __init__(self, name, residence_time, initial_inventory=0, tritium_source=0, efficiency = None):
+    def __init__(self, name, residence_time, initial_inventory=0, tritium_source=0):
         """
         Initializes a Component object.
 
@@ -22,7 +22,6 @@ class Component:
         self.output_ports = {}  # Dictionary where the key is the port name and the value is the port object
         self.tritium_inventory = initial_inventory
         self.tritium_source = tritium_source
-        self.efficiency = efficiency
 
     def add_input_port(self, port_name, incoming_fraction=1.0):
         """

--- a/example_simulation.py
+++ b/example_simulation.py
@@ -4,21 +4,21 @@ from plasma import Plasma
 from componentMap import ComponentMap
 from matplotlib import pyplot as plt
 from simulate import Simulate
-from utils import visualize_connections
+from tools.utils import visualize_connections
 
 LAMBDA = 1.73e-9 # Decay constant for tritium
 N_burn = 9.3e-7 # Tritium burn rate in the plasma
 TBR = 1.1
 tau_ofc = 2 * 3600
 tau_ifc = 4 * 3600
-I_startup = 0.7 
+I_startup = 0.5 
 TBE = 0.02
 
 
 component1 = FuelingSystem("Fueling System", N_burn, TBE, initial_inventory=I_startup)
 component2 = Component("OFC", tau_ofc, initial_inventory=0, tritium_source=N_burn * TBR)
 component3 = Component("IFC", tau_ifc)
-component4 = Plasma("Plasma", N_burn, TBE)
+component4 = Plasma("Plasma", N_burn, TBE) 
 port1 = component1.add_output_port("Port 1")
 port2 = component4.add_input_port("Port 2")
 port3 = component4.add_output_port("Port 3")
@@ -42,7 +42,7 @@ visualize_connections(component_map)
 
 simulation = Simulate(0.1, 1e5, component_map)
 t, y = simulation.run()
-# plt.figure()
-# plt.plot(t, y)
-# plt.legend(component_map.components.keys())
-# print(y[-1,:])
+plt.figure()
+plt.plot(t, y)
+plt.legend(component_map.components.keys())
+print(y[-1,:])

--- a/fuelCycle.py
+++ b/fuelCycle.py
@@ -1,0 +1,65 @@
+from fuelingSystem import FuelingSystem
+from component import Component
+from plasma import Plasma
+from componentMap import ComponentMap
+from matplotlib import pyplot as plt
+from simulate import Simulate
+from tools.utils import visualize_connections
+
+LAMBDA = 1.73e-9 # Decay constant for tritium
+N_burn = 9.3e-7 # Tritium burn rate in the plasma
+TBR = 1.1
+tau_ofc = 2 * 3600
+tau_ifc = 4 * 3600
+tau_tes = 24 * 3600
+I_startup = 0.7 
+TBE = 0.02
+tes_efficiency = 0.9
+
+# Define components
+fueling_system = FuelingSystem("Fueling System", N_burn, TBE, initial_inventory=I_startup)
+BB = Component("BB", tau_ofc, initial_inventory=0, tritium_source=N_burn * TBR)
+IFC = Component("IFC", tau_ifc)
+plasma = Plasma("Plasma", N_burn, TBE) 
+TES = Component("TES", residence_time = tau_tes)
+
+# Define ports
+port1 = fueling_system.add_output_port("Fueling to Plasma")
+port2 = plasma.add_input_port("Port 2")
+port3 = plasma.add_output_port("Plasma to IFC")
+port4 = IFC.add_input_port("Port 4")
+port5 = IFC.add_output_port("IFC to Fueling System")
+port6 = BB.add_output_port("OFC to TES")
+port7 = fueling_system.add_input_port("Port 7")
+port8 = IFC.add_input_port("Port 8")
+port9 = TES.add_output_port("TES to Fueling System")
+port10 = TES.add_output_port("TES to OFC")
+port11 = TES.add_input_port("Port 11")
+port12 = fueling_system.add_input_port("Port 12", incoming_fraction=tes_efficiency)
+port13 = BB.add_input_port("Port 13", incoming_fraction=1-tes_efficiency)
+
+# Add components to component map
+component_map = ComponentMap()
+component_map.add_component(fueling_system)
+component_map.add_component(BB)
+component_map.add_component(IFC)
+component_map.add_component(plasma)
+component_map.add_component(TES)
+
+# Connect ports
+component_map.connect_ports(fueling_system, port1, plasma, port2)
+component_map.connect_ports(plasma, port3, IFC, port4)
+component_map.connect_ports(IFC, port5, fueling_system, port7)
+component_map.connect_ports(BB, port6, TES, port11)
+component_map.connect_ports(TES, port9, fueling_system, port7)
+component_map.connect_ports(TES, port10, BB, port13)
+
+component_map.print_connected_map()
+visualize_connections(component_map)
+
+simulation = Simulate(0.1, 1e5, component_map)
+t, y = simulation.run()
+plt.figure()
+plt.plot(t, y)
+plt.legend(component_map.components.keys())
+print(f"Component inventories {y[-1]}")

--- a/simulate.py
+++ b/simulate.py
@@ -20,7 +20,6 @@ class Simulate:
         self.component_map = component_map
         self.interval = self.final_time / 100
 
-
     def run(self):
         """
         Run the simulation.
@@ -76,9 +75,10 @@ class Simulate:
         Restart the simulation by resetting time and component inventory.
         """
         self.time = []
-        self.y = np.zeros((self.n_steps + 1, len(self.initial_conditions)))
+        self.y = []
         for component, initial_condition in zip(self.components.values(), self.initial_conditions.values()):
             component.tritium_inventory = initial_condition
+        self.y = [list(self.initial_conditions.values())]
 
     def forward_euler(self):
         """
@@ -102,8 +102,9 @@ class Simulate:
             self.adaptive_timestep(y_new, self.y[-1], t)  # Update the timestep based on the new and old y values
             t += self.dt
             self.y.append(y_new) # append y_new after updating the time step
-        self.y = np.array(self.y)
-        return [self.time, self.y[:-1,:]]
+        self.y.pop() # remove the last element of y whose time is greater than the final time
+        
+        return [self.time, self.y]
 
 
     def f(self, y):

--- a/tools/component_tools.py
+++ b/tools/component_tools.py
@@ -1,7 +1,7 @@
 import numpy as np
-import molten_salts as MS
-import liquid_metals as LM
-import correlations as corr
+import tools.molten_salts as MS
+import tools.liquid_metals as LM
+import tools.correlations as corr
 
 
 def set_attribute(instance, attr_name, new_value):

--- a/tools/extractor.py
+++ b/tools/extractor.py
@@ -1,5 +1,5 @@
 import numpy
-import correlations as cor
+import tools.correlations as cor
 
 
 def extractor_lm(Z, R, G_l, G_gas, pl_in, pl_out, T, p_t, K_S):

--- a/tools/liquid_metals.py
+++ b/tools/liquid_metals.py
@@ -1,4 +1,4 @@
-import liquid_metals as lm
+import tools.liquid_metals as lm
 
 
 def W(k_r, D, thick, K_S, P_H2):

--- a/tools/molten_salts.py
+++ b/tools/molten_salts.py
@@ -1,4 +1,4 @@
-import molten_salts as ms
+import tools.molten_salts as ms
 
 
 def W(k_d, D, thick, K_S, P_H2):


### PR DESCRIPTION
Fix np.array issue by using lists only in Simulation. Removed efficiecy as a parameter from component class - use the incoming fraction when defining the port instead