### PR TITLE
Install openfc, networkx and numpy to build documentation 

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -21,7 +21,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install sphinx sphinx_rtd_theme  # Add other dependencies if needed
-        pip install myst-parser     
+        pip install myst-parser    
+        pip install git+https://github.com/SamueleMeschini/fuelcycle.git                                                                                                
     - name: Build documentation
       run: |
         cd docs/


### PR DESCRIPTION
This small change should solve the errors in the CI . It has been tested on my fork 

WARNING: autodoc: failed to import class 'component.Component' from module 'src.openfc.components'; the following exception was raised:
No module named 'openfc'
WARNING: autodoc: failed to import class 'breedingBlanket.BreedingBlanket' from module 'src.openfc.components'; the following exception was raised:
No module named 'openfc'
WARNING: autodoc: failed to import class 'fuelingSystem.FuelingSystem' from module 'src.openfc.components'; the following exception was raised:
No module named 'openfc'
WARNING: autodoc: failed to import class 'plasma.Plasma' from module 'src.openfc.components'; the following exception was raised:
No module named 'openfc'
WARNING: autodoc: failed to import class 'simulate.Simulate' from module 'src.openfc'; the following exception was raised:
No module named 'numpy'
WARNING: autodoc: failed to import function 'utils.visualize_connections' from module 'src.openfc.tools'; the following exception was raised:
No module named 'networkx'
looking for now-outdated files... none found